### PR TITLE
fix(selfsteal): add ssl volume to Caddyfile validation for manual certs

### DIFF
--- a/selfsteal.sh
+++ b/selfsteal.sh
@@ -3013,10 +3013,16 @@ validate_caddyfile() {
     fi
     
     # Валидация с теми же volume что и в рабочем контейнере
+    local ssl_volume=""
+    if [ -d "$APP_DIR/ssl" ] && [ -f "$APP_DIR/ssl/fullchain.crt" ]; then
+        ssl_volume="-v $APP_DIR/ssl:/etc/caddy/ssl:ro"
+    fi
+
     if docker run --rm \
         -v "$APP_DIR/Caddyfile:/etc/caddy/Caddyfile:ro" \
         -v "/etc/letsencrypt:/etc/letsencrypt:ro" \
         -v "$APP_DIR/html:/var/www/html:ro" \
+        $ssl_volume \
         -e "SELF_STEAL_DOMAIN=$SELF_STEAL_DOMAIN" \
         -e "SELF_STEAL_PORT=$SELF_STEAL_PORT" \
         caddy:${CADDY_VERSION}-alpine \


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                  
  - Fix Caddyfile validation failing when using manual SSL certificates (`--ssl-cert`/`--ssl-key`)                                                                                                                                                            
                                                                                                                                                                                                                                                              
  ## Problem                                                                                                                                                                                                                                                  
  When installing selfsteal with manual/wildcard SSL certificates, the installation would fail at Caddyfile validation step with:                                                                                                                             
                                                                                                                                                                                                                                                              
  Error: open /etc/caddy/ssl/fullchain.crt: no such file or directory                                                                                                                                                                                         
                                                                                                                                                                                                                                                              
  The `validate_caddyfile()` function uses a separate `docker run` command that was missing the `./ssl` volume mount. The actual container (via docker-compose) had the correct mount and would work fine — but the script never reached `docker compose up -d` because validation failed first.                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                              
  ## Solution                                                                                                                                                                                                                                                 
  Add conditional SSL volume mounting to `validate_caddyfile()` when manual certificates are present.                                                                                                                                                         
                                                                                                                                                                                                                                                              
  ## Testing                                                                                                                                                                                                                                                  
  ```bash                                                                                                                                                                                                                                                     
  selfsteal install --ssl-cert /path/to/fullchain.cer --ssl-key /path/to/private.key --domain example.com    