### PR TITLE
fix: Tor hash output parsing and missing /etc/tor directory

### DIFF
--- a/wtm.sh
+++ b/wtm.sh
@@ -635,10 +635,11 @@ install_tor() {
     TOR_CONTROL_PASSWORD=$(head -c 32 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 16)
     # Try to generate hashed password, fallback to cookie auth only if tor not available yet
     if command -v tor >/dev/null 2>&1; then
-        TOR_HASHED_PASSWORD=$(tor --hash-password "$TOR_CONTROL_PASSWORD" 2>/dev/null || echo "")
+        TOR_HASHED_PASSWORD=$(tor --hash-password "$TOR_CONTROL_PASSWORD" 2>&1 | grep "^16:")
     fi
     
-    # Save password for reference (secure permissions set below)
+                    mkdir -p /etc/tor
+        # Save password for reference (secure permissions set below)
     echo "$TOR_CONTROL_PASSWORD" > /etc/tor/.control_password
     chmod 600 /etc/tor/.control_password
     chown debian-tor:debian-tor /etc/tor/.control_password 2>/dev/null || chown tor:tor /etc/tor/.control_password 2>/dev/null || true


### PR DESCRIPTION
## Problem

Two bugs found in `install_tor_complete()` function on Ubuntu 24.04 LTS.

---

### Bug 1: `HashedControlPassword` in torrc contains full Tor log output

**Root cause:** `tor --hash-password` on Ubuntu 24.04 prints all log messages (including warnings) to **stdout**, not stderr. The existing `2>/dev/null` redirect only suppresses stderr, so the full stdout — including `[warn] You are running Tor as root. You don't need to, and you probably shouldn't.` — gets captured into `TOR_HASHED_PASSWORD` and written into `torrc`.

**Result in `/etc/tor/torrc`:**
```
HashedControlPassword Apr 13 17:03:36.810 [warn] You are running Tor as root. You don't need to, and you probably shouldn't.
16:676AFCADB82B3CCD60ACA2D71E98E6E3BFE69F5660B434AFFB06A2FAD5
```
This breaks Tor completely — it fails to parse the config and won't start.

**Fix:** pipe output through `grep "^16:"` to extract only the hash line (Tor hashes always start with `16:`).

```bash
# Before
TOR_HASHED_PASSWORD=$(tor --hash-password "$TOR_CONTROL_PASSWORD" 2>/dev/null || echo "")

# After
TOR_HASHED_PASSWORD=$(tor --hash-password "$TOR_CONTROL_PASSWORD" 2>&1 | grep "^16:")
```

---

### Bug 2: `/etc/tor/.control_password` write fails — directory does not exist

**Root cause:** On minimal Ubuntu 24.04 installations (e.g. Docker images, stripped VPS), `apt install tor` successfully installs the package but the postinst script does not always create `/etc/tor/`. The script attempts to write to `/etc/tor/.control_password` before ensuring the directory exists.

**Error:**
```
/usr/local/bin/wtm: line 642: /etc/tor/.control_password: No such file or directory
[ERROR] Command failed at line 642: echo "$TOR_CONTROL_PASSWORD" > /etc/tor/.control_password (exit code: 1)
```

**Fix:** Add `mkdir -p /etc/tor` before writing the password file.

```bash
# Before
# Save password for reference (secure permissions set below)
echo "$TOR_CONTROL_PASSWORD" > /etc/tor/.control_password

# After
mkdir -p /etc/tor
# Save password for reference (secure permissions set below)
echo "$TOR_CONTROL_PASSWORD" > /etc/tor/.control_password
```

---

## Environment
- OS: Ubuntu 24.04 LTS (Noble Numbat)
- Script version: wtm v1.3.0
- Tor installed via `apt install tor`