### PR TITLE
fix: caddy catch-all block uses tls internal causing internal_error on unknown SNI

### DIFF
--- a/selfsteal.sh
+++ b/selfsteal.sh
@@ -1920,7 +1920,7 @@ https://{$SELF_STEAL_DOMAIN} {
 }
 
 :{$SELF_STEAL_PORT} {
-	tls internal
+	tls /etc/caddy/ssl/fullchain.crt /etc/caddy/ssl/private.key
 	respond 204
 	log off
 }
@@ -1988,7 +1988,7 @@ https://{$SELF_STEAL_DOMAIN} {
 }
 
 :{$SELF_STEAL_PORT} {
-	tls internal
+	tls /data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/{$SELF_STEAL_DOMAIN}/{$SELF_STEAL_DOMAIN}.crt /data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/{$SELF_STEAL_DOMAIN}/{$SELF_STEAL_DOMAIN}.key
 	respond 204
 	log off
 }


### PR DESCRIPTION
## Проблема

В сгенерированном Caddyfile catch-all блок использует `tls internal`:

```caddyfile
:{$SELF_STEAL_PORT} {
    tls internal
    respond 204
    log off
}
```

Caddy с `tls internal` генерирует self-signed сертификат привязанный к конкретному hostname. При запросе без SNI или с неизвестным SNI Caddy не знает какой сертификат подать и закрывает соединение с `TLSV1_ALERT_INTERNAL_ERROR`.

Для DPI/ТСПУ это стабильная сигнатура: порт 443 + TCP OK + `internal_error` на нестандартный SNI однозначно указывает на VLESS REALITY ноду.

## Ожидаемое поведение

Реальный веб-сервер при неизвестном SNI отдаёт дефолтный vhost с первым доступным сертификатом — TLS handshake завершается успешно, клиент получает HTTP 200/204.

## Фикс

В catch-all блоке явно указывать реальный сертификат домена вместо `tls internal`.

Для automatic SSL:
```caddyfile
:{$SELF_STEAL_PORT} {
    tls /data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/{$SELF_STEAL_DOMAIN}/{$SELF_STEAL_DOMAIN}.crt /data/caddy/certificates/acme-v02.api.letsencrypt.org-directory/{$SELF_STEAL_DOMAIN}/{$SELF_STEAL_DOMAIN}.key
    respond 204
    log off
}
```

Для manual SSL:
```caddyfile
:{$SELF_STEAL_PORT} {
    tls /etc/caddy/ssl/fullchain.crt /etc/caddy/ssl/private.key
    respond 204
    log off
}
```

## Проверка

После фикса сервер корректно отвечает на все три сценария:

| Сценарий | До фикса | После фикса |
|---|---|---|
| Правильный SNI | ✅ TLS OK + HTTP 200 | ✅ TLS OK + HTTP 200 |
| Неверный SNI | ❌ `internal_error` | ✅ TLS OK + CERT mismatch (норма) + HTTP 204 |
| Без SNI | ❌ `internal_error` | ✅ TLS OK + HTTP 204 |